### PR TITLE
RenderWindow was calling wrong Window constructor

### DIFF
--- a/src/Graphics/RenderWindow.cs
+++ b/src/Graphics/RenderWindow.cs
@@ -52,7 +52,7 @@ namespace SFML
             /// <param name="settings">Creation parameters</param>
             ////////////////////////////////////////////////////////////
             public RenderWindow(VideoMode mode, string title, Styles style, ContextSettings settings) :
-                base(IntPtr.Zero)
+                base(IntPtr.Zero, 0)
             {
                  // Copy the string to a null-terminated UTF-32 byte array
                 byte[] titleAsUtf32 = System.Text.Encoding.UTF32.GetBytes(title + '\0');


### PR DESCRIPTION
Since commit https://github.com/LaurentGomila/SFML.Net/commit/62b70062549feee97123ee13735b634f5f88400f wrong Window constructor was called from RenderWindow

I believe it was just typing error in commit https://github.com/LaurentGomila/SFML.Net/commit/62b70062549feee97123ee13735b634f5f88400f because before adding Unicode it was already calling with 0(dummy argument) used by Window constructor to distinguish constructors for creating window from handle and constructor to just pass handle to ObjectBase.
