### PR TITLE
Loading shaders from stream broken?

### DIFF
--- a/src/Graphics/Shader.cs
+++ b/src/Graphics/Shader.cs
@@ -76,7 +76,9 @@ namespace SFML
             {
                 StreamAdaptor vertexAdaptor = new StreamAdaptor(vertexShaderStream);
                 StreamAdaptor fragmentAdaptor = new StreamAdaptor(fragmentShaderStream);
-                SetThis(sfShader_createFromStream(vertexAdaptor.InputStreamPtr, fragmentAdaptor.InputStreamPtr));
+                IntPtr vertexPtr = vertexShaderStream == null ? IntPtr.Zero : vertexAdaptor.InputStreamPtr;
+                IntPtr fragmentPtr = fragmentShaderStream == null ? IntPtr.Zero : fragmentAdaptor.InputStreamPtr;
+                SetThis(sfShader_createFromStream(vertexPtr, fragmentPtr));
                 vertexAdaptor.Dispose();
                 fragmentAdaptor.Dispose();
 


### PR DESCRIPTION
Not sure if this is a bug, or I don't know how to use the interface.
I first thought it had something to do with one of the shader streams being `null`, which is supported according to the documentation, so I tried to solve it as attached, but it still doesn't work: `sfShader_createFromStream(...)` returns null, anyways.
