### PR TITLE
GetPointCount() is now a property

### DIFF
--- a/src/Graphics/CircleShape.cs
+++ b/src/Graphics/CircleShape.cs
@@ -58,7 +58,7 @@ namespace SFML
                 base(copy)
             {
                 Radius = copy.Radius;
-                SetPointCount(copy.GetPointCount());
+                SetPointCount(copy.PointCount);
             }
 
             ////////////////////////////////////////////////////////////
@@ -74,13 +74,12 @@ namespace SFML
 
             ////////////////////////////////////////////////////////////
             /// <summary>
-            /// Get the total number of points of the shape
+            /// The total number of points of the shape
             /// </summary>
-            /// <returns>The total point count</returns>
             ////////////////////////////////////////////////////////////
-            public override uint GetPointCount()
+            public override uint PointCount
             {
-                return myPointCount;
+                get { return myPointCount; }
             }
 
             ////////////////////////////////////////////////////////////

--- a/src/Graphics/ConvexShape.cs
+++ b/src/Graphics/ConvexShape.cs
@@ -44,20 +44,19 @@ namespace SFML
             public ConvexShape(ConvexShape copy) :
                 base(copy)
             {
-                SetPointCount(copy.GetPointCount());
-                for (uint i = 0; i < copy.GetPointCount(); ++i)
+                SetPointCount(copy.PointCount);
+                for (uint i = 0; i < copy.PointCount; ++i)
                     SetPoint(i, copy.GetPoint(i));
             }
 
             ////////////////////////////////////////////////////////////
             /// <summary>
-            /// Get the total number of points of the shape
+            /// The total number of points of the shape
             /// </summary>
-            /// <returns>The total point count</returns>
             ////////////////////////////////////////////////////////////
-            public override uint GetPointCount()
+            public override uint PointCount
             {
-                return (uint)myPoints.Length;
+                get { return (uint)myPoints.Length; }
             }
 
             ////////////////////////////////////////////////////////////

--- a/src/Graphics/RectangleShape.cs
+++ b/src/Graphics/RectangleShape.cs
@@ -60,13 +60,12 @@ namespace SFML
 
             ////////////////////////////////////////////////////////////
             /// <summary>
-            /// Get the total number of points of the shape
+            /// The total number of points of the shape
             /// </summary>
-            /// <returns>The total point count</returns>
             ////////////////////////////////////////////////////////////
-            public override uint GetPointCount()
+            public override uint PointCount
             {
-                return 4;
+                get { return 4; }
             }
 
             ////////////////////////////////////////////////////////////

--- a/src/Graphics/Shape.cs
+++ b/src/Graphics/Shape.cs
@@ -71,11 +71,10 @@ namespace SFML
 
             ////////////////////////////////////////////////////////////
             /// <summary>
-            /// Get the total number of points of the shape
+            /// The total number of points of the shape
             /// </summary>
-            /// <returns>The total point count</returns>
             ////////////////////////////////////////////////////////////
-            public abstract uint GetPointCount();
+            public abstract uint PointCount { get; }
 
             ////////////////////////////////////////////////////////////
             /// <summary>
@@ -220,7 +219,7 @@ namespace SFML
             ////////////////////////////////////////////////////////////
             private uint InternalGetPointCount(IntPtr userData)
             {
-                return GetPointCount();
+                return PointCount;
             }
 
             ////////////////////////////////////////////////////////////


### PR DESCRIPTION
It was impossible to change the SetPointCount on the circle and rectangle shapes because it is impossible to change the get/set definition of a property when overriding. So this is the best I can do for this. See the following link for more information.

http://stackoverflow.com/questions/82437/why-is-it-impossible-to-override-a-getter-only-property-and-add-a-setter
