### PR TITLE
Changed input classes to be static

### DIFF
--- a/src/Window/Joystick.cs
+++ b/src/Window/Joystick.cs
@@ -11,7 +11,7 @@ namespace SFML
         /// Give access to the real-time state of the joysticks
         /// </summary>
         ////////////////////////////////////////////////////////////
-        public class Joystick
+        public static class Joystick
         {
             /// <summary>Maximum number of supported joysticks</summary>
             public static readonly uint Count = 8;

--- a/src/Window/Keyboard.cs
+++ b/src/Window/Keyboard.cs
@@ -11,7 +11,7 @@ namespace SFML
         /// Give access to the real-time state of the keyboard
         /// </summary>
         ////////////////////////////////////////////////////////////
-        public class Keyboard
+        public static class Keyboard
         {
             ////////////////////////////////////////////////////////////
             /// <summary>

--- a/src/Window/Mouse.cs
+++ b/src/Window/Mouse.cs
@@ -11,7 +11,7 @@ namespace SFML
         /// Give access to the real-time state of the mouse
         /// </summary>
         ////////////////////////////////////////////////////////////
-        public class Mouse
+        public static class Mouse
         {
             ////////////////////////////////////////////////////////////
             /// <summary>


### PR DESCRIPTION
Joystick, Keyboard, and Mouse classes only contained static members so there is no need at all to create any instances of the classes. Therefore it makes sense to mark the classes as static.
