### PR TITLE
Removed publicly exposed internal functions

### DIFF
--- a/src/Graphics/RenderWindow.cs
+++ b/src/Graphics/RenderWindow.cs
@@ -664,7 +664,7 @@ namespace SFML
             /// </summary>
             /// <returns>Relative mouse position</returns>
             ////////////////////////////////////////////////////////////
-            public override Vector2i InternalGetMousePosition()
+            protected override Vector2i InternalGetMousePosition()
             {
                 return sfMouse_getPositionRenderWindow(CPointer);
             }
@@ -677,7 +677,7 @@ namespace SFML
             /// </summary>
             /// <param name="position">Relative mouse position</param>
             ////////////////////////////////////////////////////////////
-            public override void InternalSetMousePosition(Vector2i position)
+            protected override void InternalSetMousePosition(Vector2i position)
             {
                 sfMouse_setPositionRenderWindow(position, CPointer);
             }

--- a/src/Window/Window.cs
+++ b/src/Window/Window.cs
@@ -402,12 +402,12 @@ namespace SFML
             ////////////////////////////////////////////////////////////
             /// <summary>
             /// Internal function to get the mouse position relatively to the window.
-            /// This function is public because it is called by another class of
+            /// This function is protected because it is called by another class of
             /// another module, it is not meant to be called by users.
             /// </summary>
             /// <returns>Relative mouse position</returns>
             ////////////////////////////////////////////////////////////
-            public virtual Vector2i InternalGetMousePosition()
+            protected internal virtual Vector2i InternalGetMousePosition()
             {
                 return sfMouse_getPosition(CPointer);
             }
@@ -415,12 +415,12 @@ namespace SFML
             ////////////////////////////////////////////////////////////
             /// <summary>
             /// Internal function to set the mouse position relatively to the window.
-            /// This function is public because it is called by another class of
+            /// This function is protected because it is called by another class of
             /// another module, it is not meant to be called by users.
             /// </summary>
             /// <param name="position">Relative mouse position</param>
             ////////////////////////////////////////////////////////////
-            public virtual void InternalSetMousePosition(Vector2i position)
+            protected internal virtual void InternalSetMousePosition(Vector2i position)
             {
                 sfMouse_setPosition(position, CPointer);
             }


### PR DESCRIPTION
I refactored the functions Window.InternalGetMousePosition() and Window.InternalSetMousePosition() so they are no longer publicly visible. The fix was simple, just change the protection level to 'protected internal' from 'public'.
