### PR TITLE
Fixed issue where user is able to modify the default view

### DIFF
--- a/src/Graphics/RenderTexture.cs
+++ b/src/Graphics/RenderTexture.cs
@@ -77,7 +77,7 @@ namespace SFML
             ////////////////////////////////////////////////////////////
             public View DefaultView
             {
-                get {return myDefaultView;}
+                get { return new View(myDefaultView); }
             }
 
             ////////////////////////////////////////////////////////////

--- a/src/Graphics/RenderWindow.cs
+++ b/src/Graphics/RenderWindow.cs
@@ -297,7 +297,7 @@ namespace SFML
             ////////////////////////////////////////////////////////////
             public View DefaultView
             {
-                get {return myDefaultView;}
+                get { return new View(myDefaultView); }
             }
 
             ////////////////////////////////////////////////////////////


### PR DESCRIPTION
3040eea
I'm porting the "SFML Game Development" book code to C#, and on the 3rd chapter I ran into an issue where statistics text was not drawn in window coordinates, but in world coordinates. I discovered I was modifying the default view of the RenderWindow. RenderWindow.DefaultView returns a reference to the view, which you can modify, but should not be able to:

``` cs
    internal class World
    {
      public World(RenderWindow window)
        {
            this.window = window;
            worldView = this.window.DefaultView; // Reference to the default view
            ...

      public void Update(TimeSpan dt)
        {
            worldView.Move(new Vector2f(0, scrollSpeed * (dt.Milliseconds / 1000f))); // Modifiy the window's default view
            ...
```
