### PR TITLE
Disabled redundant warnings for missing XML comments

### DIFF
--- a/src/Window/Keyboard.cs
+++ b/src/Window/Keyboard.cs
@@ -20,6 +20,9 @@ namespace SFML
             ////////////////////////////////////////////////////////////
             public enum Key
             {
+
+#pragma warning disable 1591 // Disable warnings for missing XML comments
+
                 Unknown = -1, // Unhandled key
                 A = 0,        // The A key
                 B,            // The B key
@@ -124,6 +127,9 @@ namespace SFML
                 Pause,        // The Pause key
 
                 KeyCount      // Keep last -- the total number of keyboard keys
+
+#pragma warning restore 1591 // Restore warnings for missing XML comments
+
             };
 
             ////////////////////////////////////////////////////////////


### PR DESCRIPTION
Having an XML comment for each key would be an overkill since the values are self-explanatory; added `#pragma` directive to suppress compiler warnings.
