### PR TITLE
Various convenience changes in Vector2, Sprite, Text, Rectangle, Vertex

### DIFF
--- a/src/Graphics/Rect.cs
+++ b/src/Graphics/Rect.cs
@@ -232,6 +232,18 @@ namespace SFML
 
             /// <summary>Height of the rectangle</summary>
             public int Height;
+
+			/// <summary> Right coordinate of the rectangle </summary>
+	        public int Right {
+				get { return Left + Width; }
+				set { Left = value - Width; }
+	        }
+
+			/// <summary> Bottom coordinate of the rectangle </summary>
+	        public int Bottom {
+				get { return Top + Height; }
+				set { Top = value - Width; }
+	        }
         }
         ////////////////////////////////////////////////////////////
         /// <summary>
@@ -459,6 +471,18 @@ namespace SFML
 
             /// <summary>Height of the rectangle</summary>
             public float Height;
+
+			/// <summary> Right coordinate of the rectangle </summary>
+			public float Right {
+				get { return Left + Width; }
+				set { Left = value - Width; }
+			}
+
+			/// <summary> Bottom coordinate of the rectangle </summary>
+			public float Bottom {
+				get { return Top + Height; }
+				set { Top = value - Width; }
+			}
         }
     }
 }

--- a/src/Graphics/Sprite.cs
+++ b/src/Graphics/Sprite.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Security;
 using System.Runtime.InteropServices;
+using SFML.System;
 using SFML.Window;
 
 namespace SFML
@@ -39,6 +40,19 @@ namespace SFML
             {
                 Texture = texture;
             }
+
+			////////////////////////////////////////////////////////////
+	        /// <summary>
+	        /// Construct the sprite from a source texture and position
+	        /// </summary>
+	        /// <param name="texture">Source texture to assign to the sprite</param>
+	        /// <param name="position">The position of the sprite</param>
+	        ////////////////////////////////////////////////////////////
+			public Sprite(Texture texture, Vector2f position) :
+				base(sfSprite_create()) {
+				Texture = texture;
+				Position = position;
+			}
 
             ////////////////////////////////////////////////////////////
             /// <summary>

--- a/src/Graphics/Text.cs
+++ b/src/Graphics/Text.cs
@@ -50,19 +50,7 @@ namespace SFML
             {
             }
 
-            ////////////////////////////////////////////////////////////
-            /// <summary>
-            /// Construct the text from a string and a font
-            /// </summary>
-            /// <param name="str">String to display</param>
-            /// <param name="font">Font to use</param>
-            ////////////////////////////////////////////////////////////
-            public Text(string str, Font font) :
-                this(str, font, 30)
-            {
-            }
-
-            ////////////////////////////////////////////////////////////
+	        ////////////////////////////////////////////////////////////
             /// <summary>
             /// Construct the text from a string, font and size
             /// </summary>
@@ -70,13 +58,30 @@ namespace SFML
             /// <param name="font">Font to use</param>
             /// <param name="characterSize">Base characters size</param>
             ////////////////////////////////////////////////////////////
-            public Text(string str, Font font, uint characterSize) :
+            public Text(string str, Font font, uint characterSize = 30) :
                 base(sfText_create())
             {
                 DisplayedString = str;
                 Font = font;
                 CharacterSize = characterSize;
             }
+
+			////////////////////////////////////////////////////////////
+	        /// <summary>
+	        /// Construct the text from a string, font, position and size
+	        /// </summary>
+	        /// <param name="str">String to display</param>
+	        /// <param name="font">Font to use</param>
+	        /// <param name="position">Position of the text</param>
+	        /// <param name="characterSize">Base characters size</param>
+	        ////////////////////////////////////////////////////////////
+			public Text(string str, Font font, Vector2f position, uint characterSize = 30) :
+				base(sfText_create()) {
+				DisplayedString = str;
+				Font = font;
+		        Position = position;
+				CharacterSize = characterSize;
+			}
 
             ////////////////////////////////////////////////////////////
             /// <summary>

--- a/src/Graphics/Vertex.cs
+++ b/src/Graphics/Vertex.cs
@@ -68,6 +68,15 @@ namespace SFML
                 TexCoords = texCoords;
             }
 
+			/// <summary>
+			/// Construct a vertex from a position as an operator.
+			/// </summary>
+			/// <param name="vector">The position</param>
+			/// <returns>A new Vertex from the position</returns>
+			public static explicit operator Vertex (Vector2f vector) {
+				return new Vertex(vector);
+			}
+
             ////////////////////////////////////////////////////////////
             /// <summary>
             /// Provide a string describing the object

--- a/src/System/Vector2.cs
+++ b/src/System/Vector2.cs
@@ -27,6 +27,15 @@ namespace SFML
                 Y = y;
             }
 
+			/// <summary>
+			/// Construct the vector from one coordinate.
+			/// </summary>
+			/// <param name="value">Value to set both components to</param>
+			public Vector2f(float value) {
+				X = value;
+				Y = value;
+			}
+
             ////////////////////////////////////////////////////////////
             /// <summary>
             /// Operator - overload ; returns the opposite of a vector
@@ -78,8 +87,9 @@ namespace SFML
                 return new Vector2f(v.X * x, v.Y * x);
             }
 
-            ////////////////////////////////////////////////////////////
-            /// <summary>
+	        ////////////////////////////////////////////////////////////
+
+	        /// <summary>
             /// Operator * overload ; multiply a scalar value by a vector
             /// </summary>
             /// <param name="x">Scalar value</param>
@@ -91,7 +101,18 @@ namespace SFML
                 return new Vector2f(v.X * x, v.Y * x);
             }
 
-            ////////////////////////////////////////////////////////////
+	        /// <summary>
+	        /// Operator * overload ; multiply two vectors.
+	        /// Note that this is not dot nor cross product, but instead multiplies the components together.
+	        /// </summary>
+	        /// <param name="v1">First vector</param>
+	        /// <param name="v2">Second vector</param>
+	        /// <returns>v1 * v2</returns>
+	        public static Vector2f operator *(Vector2f v1, Vector2f v2) {
+		        return new Vector2f(v1.X * v2.X, v1.Y * v2.Y);
+	        }
+
+	        ////////////////////////////////////////////////////////////
             /// <summary>
             /// Operator / overload ; divide a vector by a scalar value
             /// </summary>
@@ -232,6 +253,15 @@ namespace SFML
                 X = x;
                 Y = y;
             }
+
+			/// <summary>
+			/// Construct the vector from one coordinate
+			/// </summary>
+			/// <param name="value">Value to set both components to</param>
+			public Vector2i(int value) {
+				X = value;
+				Y = value;
+			}
 
             ////////////////////////////////////////////////////////////
             /// <summary>
@@ -438,6 +468,15 @@ namespace SFML
                 X = x;
                 Y = y;
             }
+
+			/// <summary>
+			/// Construct the vector from one coordinate
+			/// </summary>
+			/// <param name="value">Value to set both components to</param>
+			public Vector2u(uint value) {
+				X = value;
+				Y = value;
+			}
 
             ////////////////////////////////////////////////////////////
             /// <summary>


### PR DESCRIPTION
Made the following changes:
- Constructors with a single parameter to all Vector2s (sets both components to the same value)
- XNA-like Vector2f*Vector2f (component multiplication)
- Right and Bottom properties to IntRect and FloatRect
- Sprite and Text constructors accepting a Vector2f parameter, the new position of the object
- Explicit "(Vertex) Vector2f" cast

I understand if perfect compliance to the C++ API is a priority, but I think that these changes can make working with SFML.Net easier.
