### PR TITLE
Refactored the externally defined SetThis function to be more explicit as the setter of the CPointer property

### DIFF
--- a/src/Audio/Music.cs
+++ b/src/Audio/Music.cs
@@ -40,7 +40,7 @@ namespace SFML
                 base(IntPtr.Zero)
             {
                 myStream = new StreamAdaptor(stream);
-                SetThis(sfMusic_createFromStream(myStream.InputStreamPtr));
+                CPointer = sfMusic_createFromStream(myStream.InputStreamPtr);
 
                 if (CPointer == IntPtr.Zero)
                     throw new LoadingFailedException("music");
@@ -59,7 +59,7 @@ namespace SFML
                 GCHandle pin = GCHandle.Alloc(bytes, GCHandleType.Pinned);
                 try 
                 {
-                    SetThis(sfMusic_createFromMemory(pin.AddrOfPinnedObject(), Convert.ToUInt64(bytes.Length)));
+                    CPointer = sfMusic_createFromMemory(pin.AddrOfPinnedObject(), Convert.ToUInt64(bytes.Length));
                 } 
                 finally 
                 {

--- a/src/Audio/SoundBuffer.cs
+++ b/src/Audio/SoundBuffer.cs
@@ -43,7 +43,7 @@ namespace SFML
             {
                 using (StreamAdaptor adaptor = new StreamAdaptor(stream))
                 {
-                    SetThis(sfSoundBuffer_createFromStream(adaptor.InputStreamPtr));
+                    CPointer = sfSoundBuffer_createFromStream(adaptor.InputStreamPtr);
                 }
 
                 if (CPointer == IntPtr.Zero)
@@ -63,7 +63,7 @@ namespace SFML
                 GCHandle pin = GCHandle.Alloc(bytes, GCHandleType.Pinned);
                 try 
                 {
-                    SetThis(sfSoundBuffer_createFromMemory(pin.AddrOfPinnedObject(), Convert.ToUInt64(bytes.Length)));
+                    CPointer = sfSoundBuffer_createFromMemory(pin.AddrOfPinnedObject(), Convert.ToUInt64(bytes.Length));
                 } 
                 finally 
                 {
@@ -89,7 +89,7 @@ namespace SFML
                 {
                     fixed (short* SamplesPtr = samples)
                     {
-                        SetThis(sfSoundBuffer_createFromSamples(SamplesPtr, (uint)samples.Length, channelCount, sampleRate));
+                        CPointer = sfSoundBuffer_createFromSamples(SamplesPtr, (uint)samples.Length, channelCount, sampleRate);
                     }
                 }
 

--- a/src/Audio/SoundRecorder.cs
+++ b/src/Audio/SoundRecorder.cs
@@ -26,7 +26,7 @@ namespace SFML
                 myProcessCallback = new ProcessCallback(ProcessSamples);
                 myStopCallback    = new StopCallback(OnStop);
 
-                SetThis(sfSoundRecorder_create(myStartCallback, myProcessCallback, myStopCallback, IntPtr.Zero));
+                CPointer = sfSoundRecorder_create(myStartCallback, myProcessCallback, myStopCallback, IntPtr.Zero);
             }
 
             ////////////////////////////////////////////////////////////

--- a/src/Audio/SoundStream.cs
+++ b/src/Audio/SoundStream.cs
@@ -222,7 +222,7 @@ namespace SFML
             {
                 myGetDataCallback = new GetDataCallbackType(GetData);
                 mySeekCallback    = new SeekCallbackType(Seek);
-                SetThis(sfSoundStream_create(myGetDataCallback, mySeekCallback, channelCount, sampleRate, IntPtr.Zero));
+                CPointer = sfSoundStream_create(myGetDataCallback, mySeekCallback, channelCount, sampleRate, IntPtr.Zero);
             }
 
             ////////////////////////////////////////////////////////////

--- a/src/Graphics/Font.cs
+++ b/src/Graphics/Font.cs
@@ -43,7 +43,7 @@ namespace SFML
                 base(IntPtr.Zero)
             {
                 myStream = new StreamAdaptor(stream);
-                SetThis(sfFont_createFromStream(myStream.InputStreamPtr));
+                CPointer = sfFont_createFromStream(myStream.InputStreamPtr);
 
                 if (CPointer == IntPtr.Zero)
                     throw new LoadingFailedException("font");
@@ -62,7 +62,7 @@ namespace SFML
                 GCHandle pin = GCHandle.Alloc(bytes, GCHandleType.Pinned);
                 try 
                 {
-                    SetThis(sfFont_createFromMemory(pin.AddrOfPinnedObject(), Convert.ToUInt64(bytes.Length)));
+                    CPointer = sfFont_createFromMemory(pin.AddrOfPinnedObject(), Convert.ToUInt64(bytes.Length));
                 } 
                 finally 
                 {

--- a/src/Graphics/Image.cs
+++ b/src/Graphics/Image.cs
@@ -73,7 +73,7 @@ namespace SFML
             {
                 using (StreamAdaptor adaptor = new StreamAdaptor(stream))
                 {
-                    SetThis(sfImage_createFromStream(adaptor.InputStreamPtr));
+                    CPointer = sfImage_createFromStream(adaptor.InputStreamPtr);
                 }
 
                 if (CPointer == IntPtr.Zero)
@@ -93,7 +93,7 @@ namespace SFML
                 GCHandle pin = GCHandle.Alloc(bytes, GCHandleType.Pinned);
                 try 
                 {
-                    SetThis(sfImage_createFromMemory(pin.AddrOfPinnedObject(), Convert.ToUInt64(bytes.Length)));
+                    CPointer = sfImage_createFromMemory(pin.AddrOfPinnedObject(), Convert.ToUInt64(bytes.Length));
                 } 
                 finally 
                 {
@@ -126,7 +126,7 @@ namespace SFML
                 {
                     fixed (Color* PixelsPtr = transposed)
                     {
-                        SetThis(sfImage_createFromPixels(Width, Height, (byte*)PixelsPtr));
+                        CPointer = sfImage_createFromPixels(Width, Height, (byte*)PixelsPtr);
                     }
                 }
 
@@ -150,7 +150,7 @@ namespace SFML
                 {
                     fixed (byte* PixelsPtr = pixels)
                     {
-                        SetThis(sfImage_createFromPixels(width, height, PixelsPtr));
+                        CPointer = sfImage_createFromPixels(width, height, PixelsPtr);
                     }
                 }
 

--- a/src/Graphics/RenderWindow.cs
+++ b/src/Graphics/RenderWindow.cs
@@ -63,7 +63,7 @@ namespace SFML
                 {
                     fixed (byte* titlePtr = titleAsUtf32)
                     {
-                        SetThis(sfRenderWindow_createUnicode(mode, (IntPtr)titlePtr, style, ref settings));
+                        CPointer = sfRenderWindow_createUnicode(mode, (IntPtr)titlePtr, style, ref settings);
                     }
                 }
                 Initialize();

--- a/src/Graphics/Shader.cs
+++ b/src/Graphics/Shader.cs
@@ -77,7 +77,7 @@ namespace SFML
             {
                 StreamAdaptor vertexAdaptor = new StreamAdaptor(vertexShaderStream);
                 StreamAdaptor fragmentAdaptor = new StreamAdaptor(fragmentShaderStream);
-                SetThis(sfShader_createFromStream(vertexAdaptor.InputStreamPtr, fragmentAdaptor.InputStreamPtr));
+                CPointer = sfShader_createFromStream(vertexAdaptor.InputStreamPtr, fragmentAdaptor.InputStreamPtr);
                 vertexAdaptor.Dispose();
                 fragmentAdaptor.Dispose();
 

--- a/src/Graphics/Shape.cs
+++ b/src/Graphics/Shape.cs
@@ -160,7 +160,7 @@ namespace SFML
             {
                 myGetPointCountCallback = new GetPointCountCallbackType(InternalGetPointCount);
                 myGetPointCallback = new GetPointCallbackType(InternalGetPoint);
-                SetThis(sfShape_create(myGetPointCountCallback, myGetPointCallback, IntPtr.Zero));
+                CPointer = sfShape_create(myGetPointCountCallback, myGetPointCallback, IntPtr.Zero);
             }
 
             ////////////////////////////////////////////////////////////
@@ -174,7 +174,7 @@ namespace SFML
             {
                 myGetPointCountCallback = new GetPointCountCallbackType(InternalGetPointCount);
                 myGetPointCallback = new GetPointCallbackType(InternalGetPoint);
-                SetThis(sfShape_create(myGetPointCountCallback, myGetPointCallback, IntPtr.Zero));
+                CPointer = sfShape_create(myGetPointCountCallback, myGetPointCallback, IntPtr.Zero);
 
                 Origin = copy.Origin;
                 Position = copy.Position;

--- a/src/Graphics/Texture.cs
+++ b/src/Graphics/Texture.cs
@@ -84,7 +84,7 @@ namespace SFML
             {
                 using (StreamAdaptor adaptor = new StreamAdaptor(stream))
                 {
-                    SetThis(sfTexture_createFromStream(adaptor.InputStreamPtr, ref area));
+                    CPointer = sfTexture_createFromStream(adaptor.InputStreamPtr, ref area);
                 }
 
                 if (CPointer == IntPtr.Zero)
@@ -132,7 +132,7 @@ namespace SFML
                 try 
                 {
                     IntRect rect = new IntRect(0, 0, 0, 0);
-                    SetThis(sfTexture_createFromMemory(pin.AddrOfPinnedObject(), Convert.ToUInt64(bytes.Length), ref rect));
+                    CPointer = sfTexture_createFromMemory(pin.AddrOfPinnedObject(), Convert.ToUInt64(bytes.Length), ref rect);
                 } 
                 finally 
                 {

--- a/src/System/ObjectBase.cs
+++ b/src/System/ObjectBase.cs
@@ -41,6 +41,7 @@ namespace SFML
         public IntPtr CPointer
         {
             get { return myCPointer; }
+            protected set { myCPointer = value; }
         }
 
         ////////////////////////////////////////////////////////////
@@ -76,17 +77,6 @@ namespace SFML
         /// <param name="disposing">Is the GC disposing the object, or is it an explicit call ?</param>
         ////////////////////////////////////////////////////////////
         protected abstract void Destroy(bool disposing);
-
-        ////////////////////////////////////////////////////////////
-        /// <summary>
-        /// Set the pointer to the internal object. For internal use only
-        /// </summary>
-        /// <param name="cPointer">Pointer to the internal object in C library</param>
-        ////////////////////////////////////////////////////////////
-        protected void SetThis(IntPtr cPointer)
-        {
-            myCPointer = cPointer;
-        }
 
         private IntPtr myCPointer = IntPtr.Zero;
     }

--- a/src/Window/Window.cs
+++ b/src/Window/Window.cs
@@ -88,7 +88,7 @@ namespace SFML
                 {
                     fixed (byte* titlePtr = titleAsUtf32)
                     {
-                        SetThis(sfWindow_createUnicode(mode, (IntPtr)titlePtr, style, ref settings));
+                        CPointer = sfWindow_createUnicode(mode, (IntPtr)titlePtr, style, ref settings);
                     }
                 }
            }


### PR DESCRIPTION
There was no good reason for the SetThis function, moving it to the property setter is more C#ish and is still only accessible by derived classes.
