### PR TITLE
Fixes Equals stack overflow

### DIFF
--- a/src/Graphics/BlendMode.cs
+++ b/src/Graphics/BlendMode.cs
@@ -157,7 +157,7 @@ namespace SFML
             ////////////////////////////////////////////////////////////
             public override bool Equals(object obj)
             {
-                return (obj is BlendMode) && obj.Equals(this);
+                return (obj is BlendMode) && Equals((BlendMode)obj);
             }
 
             ///////////////////////////////////////////////////////////

--- a/src/Graphics/Color.cs
+++ b/src/Graphics/Color.cs
@@ -78,7 +78,7 @@ namespace SFML
             ////////////////////////////////////////////////////////////
             public override bool Equals(object obj)
             {
-                return (obj is Color) && obj.Equals(this);
+                return (obj is Color) && Equals((Color)obj);
             }
             
             ///////////////////////////////////////////////////////////

--- a/src/Graphics/Rect.cs
+++ b/src/Graphics/Rect.cs
@@ -148,7 +148,7 @@ namespace SFML
             ////////////////////////////////////////////////////////////
             public override bool Equals(object obj)
             {
-                return (obj is IntRect) && obj.Equals(this);
+                return (obj is IntRect) && Equals((IntRect)obj);
             }
             
             ///////////////////////////////////////////////////////////
@@ -375,7 +375,7 @@ namespace SFML
             ////////////////////////////////////////////////////////////
             public override bool Equals(object obj)
             {
-                return (obj is FloatRect) && obj.Equals(this);
+                return (obj is FloatRect) && Equals((FloatRect)obj);
             }
             
             ///////////////////////////////////////////////////////////

--- a/src/System/Time.cs
+++ b/src/System/Time.cs
@@ -116,7 +116,7 @@ namespace SFML.System
         ////////////////////////////////////////////////////////////
         public override bool Equals(object obj)
         {
-            return (obj is Time) && obj.Equals(this);
+            return (obj is Time) && Equals((Time)obj);
         }
 
         ///////////////////////////////////////////////////////////

--- a/src/System/Vector2.cs
+++ b/src/System/Vector2.cs
@@ -152,7 +152,7 @@ namespace SFML
             ////////////////////////////////////////////////////////////
             public override bool Equals(object obj)
             {
-                return (obj is Vector2f) && obj.Equals(this);
+                return (obj is Vector2f) && Equals((Vector2f)obj);
             }
 
             ///////////////////////////////////////////////////////////
@@ -358,7 +358,7 @@ namespace SFML
             ////////////////////////////////////////////////////////////
             public override bool Equals(object obj)
             {
-                return (obj is Vector2i) && obj.Equals(this);
+                return (obj is Vector2i) && Equals((Vector2i)obj);
             }
 
             ///////////////////////////////////////////////////////////
@@ -552,7 +552,7 @@ namespace SFML
             ////////////////////////////////////////////////////////////
             public override bool Equals(object obj)
             {
-                return (obj is Vector2u) && obj.Equals(this);
+                return (obj is Vector2u) && Equals((Vector2u)obj);
             }
 
             ///////////////////////////////////////////////////////////

--- a/src/System/Vector3.cs
+++ b/src/System/Vector3.cs
@@ -155,7 +155,7 @@ namespace SFML
             ////////////////////////////////////////////////////////////
             public override bool Equals(object obj)
             {
-                return (obj is Vector3f) && obj.Equals(this);
+                return (obj is Vector3f) && Equals((Vector3f)obj);
             }
 
             ///////////////////////////////////////////////////////////


### PR DESCRIPTION
Previously a stack overflow would occur due to the two objects calling their respective object.Equals overrides over and over again. Now they call the IEquatable version as intended.