### PR TITLE
Corrected Glyph.Advance type

### DIFF
--- a/src/Graphics/Glyph.cs
+++ b/src/Graphics/Glyph.cs
@@ -14,7 +14,7 @@ namespace SFML
         public struct Glyph
         {
             /// <summary>Offset to move horizontically to the next character</summary>
-            public int Advance;
+            public float Advance;
 
             /// <summary>Bounding rectangle of the glyph, in coordinates relative to the baseline</summary>
             public FloatRect Bounds;


### PR DESCRIPTION
Missed it somehow in the other commit when changing the types to floats.